### PR TITLE
[BUG] Handle when no pricing information available

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,6 @@ The API will return an array of `Drink` objects, i.e. POJOs with the following p
     vegan: false
 }
 ```
+
+**Note:** Pricing information for drinks will not always be available, in which case the `price` will be reported as `null`
+and the `formattedPrice` will be reported as `'Unknown'`.

--- a/lib/common-types/drink.ts
+++ b/lib/common-types/drink.ts
@@ -3,7 +3,7 @@ export type Drink = {
     brewery: string;
     style: string;
     available: boolean;
-    price: number;
+    price: number|null;
     formattedPrice: string;
     quantity: 'pint'|'half';
     currency: string;

--- a/lib/page-objects/drinks-board/drinks-board-page.ts
+++ b/lib/page-objects/drinks-board/drinks-board-page.ts
@@ -47,12 +47,24 @@ export class DrinksBoardPage implements IDrinksBoardPage {
         const pricingElement = this.page('.beer-price', rawDrink).text();
         const price = pricingElement.match(/£(\d+\.\d+)/);
 
+        // If no pricing information is available just return `null`
+        // Sometimes prices are listed as "Ask" instead of a numerical value
+        if (!price) {
+            return null;
+        }
+
         return parseFloat(price[1]);
     }
 
     private getFormattedDrinkPrice (rawDrink: CheerioElement): string {
         const pricingElement = this.page('.beer-price', rawDrink).text();
         const price = pricingElement.match(/(£\d+\.\d+)/);
+
+        // If no pricing information is available just return "Unknown"
+        // Sometimes prices are listed as "Ask" instead of a numerical value
+        if (!price) {
+            return 'Unknown';
+        }
 
         return price[1];
     }

--- a/test/fixtures/ask-for-price.html
+++ b/test/fixtures/ask-for-price.html
@@ -1,0 +1,87 @@
+
+
+
+<!DOCTYPE html>
+<html>
+<head>
+        <title>Beer Board | Urban Tap House</title>
+
+
+    <meta content="Urban Tap House" name="author" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="refresh" content="300" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+    <meta content="" name="description" />
+    <meta content="" name="keywords" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+
+</head>
+<body class="pre-load">
+    <header>
+        <div class="header-slider">
+            <ul class="bxslider">
+                <li>On Keg</li>
+            </ul>
+        </div>
+    </header>
+    <div class="beer-grid-slider">
+        <ul class="beer-slider">
+            <li>
+                <div class="beer-grid max-items-16">
+
+                            <div class="beer-item">
+                                <div class="beer-top">
+                                    <p class="beer-name">Hadouken </p>
+                                    <p class="beer-price"><span>&frac12;</span> Ask</p>
+                                </div>
+                                <div class="beer-bottom">
+                                    <p class="beer-brewery">Tiny Rebel Brewing Co. (Newport, South Wales)</p>
+                                    <p class="beer-style">Double India Pale Ale</p>
+                                    <p class="beer-abv">7.4%</p>
+                                </div>
+                            </div>
+
+                </div>
+            </li>
+        </ul>
+
+    </div>
+    <footer>
+        <p>Allergens are present in the above items; please ask one of our team for detailed information.</p>
+    </footer>
+
+    <link href='https://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
+    <link href="/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="/css/uth-bb-styles.css?v=2" rel="stylesheet" />
+    <link href="/css/jquery.bxslider.css" property="stylesheet" rel="stylesheet" />
+
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="/scripts/jquery.bxslider.min.js"></script>
+    <script type="text/javascript">
+        $(document).ready(function () {
+            var headerslider = $('.bxslider').bxSlider({
+                slideMargin: 0,
+                pager: false,
+                auto: false,
+                controls: false,
+                onSliderLoad: function () {
+                    $("body").removeClass("pre-load");
+                }
+            });
+
+            var beerslider = $('.beer-slider').bxSlider({
+                slideMargin: 0,
+                pager: false,
+                auto: false,
+                controls: false
+            });
+
+            window.setInterval(function () {
+                headerslider.goToNextSlide();
+                beerslider.goToNextSlide();
+            }, 30000);
+
+        });
+    </script>
+</body>
+</html>

--- a/test/unit/page-objects/drinks-board-page.spec.ts
+++ b/test/unit/page-objects/drinks-board-page.spec.ts
@@ -246,4 +246,27 @@ describe('drinks board page', () => {
             expect(drink.formattedPrice).to.equal('£3.45');
         });
     });
+
+    describe('when parsing a page with a drink that has no pricing information', () => {
+        let drinksBoardPage: IDrinksBoardPage;
+        let drink: Drink;
+
+        beforeEach(() => {
+            pageFixture = fs.readFileSync(
+              path.join(__dirname, '../../../../../test/fixtures/ask-for-price.html')
+            ).toString();
+
+            drinksBoardPage = drinksBoardPageFactory.createDrinksBoardPage(pageFixture);
+
+            drink = drinksBoardPage.getAllDrinks()[0];
+        });
+
+        it('should report the price as being null', () => {
+            expect(drink.price).to.equal(null);
+        });
+
+        it('should output the formatted price as being "Unknown"', () => {
+            expect(drink.formattedPrice).to.equal('Unknown');
+        });
+    });
 });


### PR DESCRIPTION
Sometimes beer is not listed with a price, e.g. instead of a price the text "Ask" is shown.

This was causing an error as it was assumed it would always be a number.

This has now been changed to handle that scenario by reporting the beer price as `null`, and the formatted price as `'Unknown'`.

![screen shot 2016-12-12 at 15 24 23](https://cloud.githubusercontent.com/assets/3420620/21109928/194409ee-c093-11e6-80f9-65e1ae8a26ad.png)
