### PR TITLE
Fix price parsing issue when no pence value

### DIFF
--- a/lib/page-objects/drinks-board/drinks-board-page.ts
+++ b/lib/page-objects/drinks-board/drinks-board-page.ts
@@ -45,7 +45,7 @@ export class DrinksBoardPage implements IDrinksBoardPage {
 
     private getDrinkPrice (rawDrink: CheerioElement): number {
         const pricingElement = this.page('.beer-price', rawDrink).text();
-        const price = pricingElement.match(/£(\d+\.\d+)/);
+        const price = pricingElement.match(/£(\d+(\.\d+)?)/);
 
         // If no pricing information is available just return `null`
         // Sometimes prices are listed as "Ask" instead of a numerical value
@@ -58,15 +58,20 @@ export class DrinksBoardPage implements IDrinksBoardPage {
 
     private getFormattedDrinkPrice (rawDrink: CheerioElement): string {
         const pricingElement = this.page('.beer-price', rawDrink).text();
-        const price = pricingElement.match(/(£\d+\.\d+)/);
+        const priceMatch = pricingElement.match(/(\d+(\.\d+)?)/);
 
         // If no pricing information is available just return "Unknown"
         // Sometimes prices are listed as "Ask" instead of a numerical value
-        if (!price) {
+        if (!priceMatch) {
             return 'Unknown';
         }
 
-        return price[1];
+        let price = priceMatch[1];
+
+        // Force price to 2dp
+        price = parseFloat(price).toFixed(2);
+
+        return `£${price}`;
     }
 
     private getFormattedABV(rawDrink: CheerioElement): string {

--- a/test/fixtures/integer-price.html
+++ b/test/fixtures/integer-price.html
@@ -1,0 +1,87 @@
+
+
+
+<!DOCTYPE html>
+<html>
+<head>
+        <title>Beer Board | Urban Tap House</title>
+
+
+    <meta content="Urban Tap House" name="author" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="refresh" content="300" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+    <meta content="" name="description" />
+    <meta content="" name="keywords" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+
+</head>
+<body class="pre-load">
+    <header>
+        <div class="header-slider">
+            <ul class="bxslider">
+                <li>On Keg</li>
+            </ul>
+        </div>
+    </header>
+    <div class="beer-grid-slider">
+        <ul class="beer-slider">
+            <li>
+                <div class="beer-grid max-items-16">
+
+                            <div class="beer-item">
+                                <div class="beer-top">
+                                    <p class="beer-name">Huck </p>
+                                    <p class="beer-price">&pound;5</p>
+                                </div>
+                                <div class="beer-bottom">
+                                    <p class="beer-brewery">Thornbridge (Bakewell, Derbyshire)</p>
+                                    <p class="beer-style">IPA</p>
+                                    <p class="beer-abv">7.4%</p>
+                                </div>
+                            </div>
+
+                </div>
+            </li>
+        </ul>
+
+    </div>
+    <footer>
+        <p>Allergens are present in the above items; please ask one of our team for detailed information.</p>
+    </footer>
+
+    <link href='https://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
+    <link href="/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="/css/uth-bb-styles.css?v=2" rel="stylesheet" />
+    <link href="/css/jquery.bxslider.css" property="stylesheet" rel="stylesheet" />
+
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="/scripts/jquery.bxslider.min.js"></script>
+    <script type="text/javascript">
+        $(document).ready(function () {
+            var headerslider = $('.bxslider').bxSlider({
+                slideMargin: 0,
+                pager: false,
+                auto: false,
+                controls: false,
+                onSliderLoad: function () {
+                    $("body").removeClass("pre-load");
+                }
+            });
+
+            var beerslider = $('.beer-slider').bxSlider({
+                slideMargin: 0,
+                pager: false,
+                auto: false,
+                controls: false
+            });
+
+            window.setInterval(function () {
+                headerslider.goToNextSlide();
+                beerslider.goToNextSlide();
+            }, 30000);
+
+        });
+    </script>
+</body>
+</html>

--- a/test/unit/page-objects/drinks-board-page.spec.ts
+++ b/test/unit/page-objects/drinks-board-page.spec.ts
@@ -269,4 +269,27 @@ describe('drinks board page', () => {
             expect(drink.formattedPrice).to.equal('Unknown');
         });
     });
+
+    describe('when parsing a page with a drink with an integer price value (e.g. "£5")', () => {
+        let drinksBoardPage: IDrinksBoardPage;
+        let drink: Drink;
+
+        beforeEach(() => {
+            pageFixture = fs.readFileSync(
+              path.join(__dirname, '../../../../../test/fixtures/integer-price.html')
+            ).toString();
+
+            drinksBoardPage = drinksBoardPageFactory.createDrinksBoardPage(pageFixture);
+
+            drink = drinksBoardPage.getAllDrinks()[0];
+        });
+
+        it('should report the price as "5.0"', () => {
+            expect(drink.price).to.equal(5.0);
+        });
+
+        it('should report the formatted price as "£5.00"', () => {
+            expect(drink.formattedPrice).to.equal('£5.00');
+        });
+    });
 });


### PR DESCRIPTION
When a drink price is specified as an integer value, e.g. "£5", it was not being parsed correctly as the library previously assumed that a pence value would be specified.

As a result, the price would be reported as "null", and the formatted price reported as "Unknown".

This fixes the issue and adds a test case for it.

Given a price of "£5" on the beer board, the drink price will now be reported as "5" and the formatted price reported as "£5.00".

Fixes #8.