### PR TITLE
[BUG] Support drinks sold in thirds

### DIFF
--- a/lib/common-types/drink.ts
+++ b/lib/common-types/drink.ts
@@ -1,4 +1,4 @@
-export type Quantity = 'pint'|'half'|'third';
+export type Quantity = 'pint'|'half'|'third'|'two-thirds';
 
 export type Drink = {
     name: string;

--- a/lib/common-types/drink.ts
+++ b/lib/common-types/drink.ts
@@ -1,3 +1,5 @@
+export type Quantity = 'pint'|'half'|'third';
+
 export type Drink = {
     name: string;
     brewery: string;
@@ -5,7 +7,7 @@ export type Drink = {
     available: boolean;
     price: number|null;
     formattedPrice: string;
-    quantity: 'pint'|'half';
+    quantity: Quantity;
     currency: string;
     abv: number;
     formattedAbv: string;

--- a/lib/common-types/index.ts
+++ b/lib/common-types/index.ts
@@ -1,1 +1,1 @@
-export { Drink } from './drink';
+export * from './drink';

--- a/lib/page-objects/drinks-board/drinks-board-page.ts
+++ b/lib/page-objects/drinks-board/drinks-board-page.ts
@@ -1,4 +1,4 @@
-import { Drink } from '../../common-types';
+import { Drink, Quantity } from '../../common-types';
 import { IDrinksBoardPage } from './drinks-board-page-interface';
 
 export class DrinksBoardPage implements IDrinksBoardPage {
@@ -94,12 +94,16 @@ export class DrinksBoardPage implements IDrinksBoardPage {
         return parseFloat(this.page('.beer-abv', rawDrink).text().replace('%', ''));
     }
 
-    private getDrinkQuantity (rawDrink: CheerioElement): ('pint'|'half') {
+    private getDrinkQuantity (rawDrink: CheerioElement): Quantity {
         // The quantity that the drink is sold in is contained in the same element as the price
         const pricingText = this.page('.beer-price', rawDrink).text();
 
         if (pricingText.indexOf('½') !== -1) {
             return 'half';
+        }
+
+        if (pricingText.indexOf('⅓') !== -1) {
+            return 'third';
         }
 
         return 'pint';

--- a/lib/page-objects/drinks-board/drinks-board-page.ts
+++ b/lib/page-objects/drinks-board/drinks-board-page.ts
@@ -106,6 +106,10 @@ export class DrinksBoardPage implements IDrinksBoardPage {
             return 'third';
         }
 
+        if (pricingText.indexOf('⅔') !== -1) {
+            return 'two-thirds';
+        }
+
         return 'pint';
     }
 

--- a/test/fixtures/third-pint.html
+++ b/test/fixtures/third-pint.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+
+
+<html>
+
+<head>
+    <title>Beer Board | Urban Tap House</title>
+
+
+    <meta content="Urban Tap House" name="author" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="refresh" content="300" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+    <meta content="" name="description" />
+    <meta content="" name="keywords" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+
+</head>
+
+<body class="pre-load">
+    <header>
+        <div class="header-slider">
+            <ul class="bxslider">
+                <li>On Keg</li>
+            </ul>
+        </div>
+    </header>
+    <div class="beer-grid-slider">
+        <ul class="beer-slider">
+            <li>
+                <div class="beer-grid max-items-16">
+
+                    <div class="beer-item">
+                        <div class="beer-top">
+                            <p class="beer-name">Huck </p>
+                            <p class="beer-price"><span>&frac13;</span> &pound;2.95</p>
+                        </div>
+                        <div class="beer-bottom">
+                            <p class="beer-brewery">Thornbridge (Bakewell, Derbyshire)</p>
+                            <p class="beer-style">IPA</p>
+                            <p class="beer-abv">8.9%</p>
+                        </div>
+                    </div>
+
+                </div>
+            </li>
+        </ul>
+
+    </div>
+    <footer>
+        <p>Allergens are present in the above items; please ask one of our team for detailed information.</p>
+    </footer>
+
+    <link href='https://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
+    <link href="/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="/css/uth-bb-styles.css?v=2" rel="stylesheet" />
+    <link href="/css/jquery.bxslider.css" property="stylesheet" rel="stylesheet" />
+
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="/scripts/jquery.bxslider.min.js"></script>
+    <script type="text/javascript">
+        $(document).ready(function () {
+            var headerslider = $('.bxslider').bxSlider({
+                slideMargin: 0,
+                pager: false,
+                auto: false,
+                controls: false,
+                onSliderLoad: function () {
+                    $("body").removeClass("pre-load");
+                }
+            });
+
+            var beerslider = $('.beer-slider').bxSlider({
+                slideMargin: 0,
+                pager: false,
+                auto: false,
+                controls: false
+            });
+
+            window.setInterval(function () {
+                headerslider.goToNextSlide();
+                beerslider.goToNextSlide();
+            }, 30000);
+
+        });
+    </script>
+</body>
+
+</html>

--- a/test/fixtures/two-thirds-pint.html
+++ b/test/fixtures/two-thirds-pint.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+
+
+<html>
+
+<head>
+    <title>Beer Board | Urban Tap House</title>
+
+
+    <meta content="Urban Tap House" name="author" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="refresh" content="300" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+    <meta content="" name="description" />
+    <meta content="" name="keywords" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+
+</head>
+
+<body class="pre-load">
+    <header>
+        <div class="header-slider">
+            <ul class="bxslider">
+                <li>On Keg</li>
+            </ul>
+        </div>
+    </header>
+    <div class="beer-grid-slider">
+        <ul class="beer-slider">
+            <li>
+                <div class="beer-grid max-items-16">
+
+                    <div class="beer-item">
+                        <div class="beer-top">
+                            <p class="beer-name">Huck </p>
+                            <p class="beer-price"><span>&frac23;</span> &pound;2.45</p>
+                        </div>
+                        <div class="beer-bottom">
+                            <p class="beer-brewery">Thornbridge (Bakewell, Derbyshire)</p>
+                            <p class="beer-style">Double IPA</p>
+                            <p class="beer-abv">12%</p>
+                        </div>
+                    </div>
+
+                </div>
+            </li>
+        </ul>
+
+    </div>
+    <footer>
+        <p>Allergens are present in the above items; please ask one of our team for detailed information.</p>
+    </footer>
+
+    <link href='https://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
+    <link href="/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="/css/uth-bb-styles.css?v=2" rel="stylesheet" />
+    <link href="/css/jquery.bxslider.css" property="stylesheet" rel="stylesheet" />
+
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="/scripts/jquery.bxslider.min.js"></script>
+    <script type="text/javascript">
+        $(document).ready(function () {
+            var headerslider = $('.bxslider').bxSlider({
+                slideMargin: 0,
+                pager: false,
+                auto: false,
+                controls: false,
+                onSliderLoad: function () {
+                    $("body").removeClass("pre-load");
+                }
+            });
+
+            var beerslider = $('.beer-slider').bxSlider({
+                slideMargin: 0,
+                pager: false,
+                auto: false,
+                controls: false
+            });
+
+            window.setInterval(function () {
+                headerslider.goToNextSlide();
+                beerslider.goToNextSlide();
+            }, 30000);
+
+        });
+    </script>
+</body>
+
+</html>

--- a/test/unit/page-objects/drinks-board-page.spec.ts
+++ b/test/unit/page-objects/drinks-board-page.spec.ts
@@ -274,6 +274,33 @@ describe('drinks board page', () => {
         });
     });
 
+    describe('when parsing a page with a drink sold in two-thirds', () => {
+        let drinksBoardPage: IDrinksBoardPage;
+        let drink: Drink;
+
+        beforeEach(() => {
+            pageFixture = fs.readFileSync(
+              path.join(__dirname, '../../../../../test/fixtures/two-thirds-pint.html')
+            ).toString();
+
+            drinksBoardPage = drinksBoardPageFactory.createDrinksBoardPage(pageFixture);
+
+            drink = drinksBoardPage.getAllDrinks()[0];
+        });
+
+        it('should correctly identify the quantity of drink', () => {
+            expect(drink.quantity).to.equal('two-thirds');
+        });
+
+        it('should correctly identify the price of the drink', () => {
+            expect(drink.price).to.equal(2.45);
+        });
+
+        it('should include the formatted price of the drink', () => {
+            expect(drink.formattedPrice).to.equal('£2.45');
+        });
+    });
+
     describe('when parsing a page with a drink that has no pricing information', () => {
         let drinksBoardPage: IDrinksBoardPage;
         let drink: Drink;

--- a/test/unit/page-objects/drinks-board-page.spec.ts
+++ b/test/unit/page-objects/drinks-board-page.spec.ts
@@ -247,6 +247,33 @@ describe('drinks board page', () => {
         });
     });
 
+    describe('when parsing a page with a drink sold in thirds', () => {
+        let drinksBoardPage: IDrinksBoardPage;
+        let drink: Drink;
+
+        beforeEach(() => {
+            pageFixture = fs.readFileSync(
+              path.join(__dirname, '../../../../../test/fixtures/third-pint.html')
+            ).toString();
+
+            drinksBoardPage = drinksBoardPageFactory.createDrinksBoardPage(pageFixture);
+
+            drink = drinksBoardPage.getAllDrinks()[0];
+        });
+
+        it('should correctly identify the quantity of drink', () => {
+            expect(drink.quantity).to.equal('third');
+        });
+
+        it('should correctly identify the price of the drink', () => {
+            expect(drink.price).to.equal(2.95);
+        });
+
+        it('should include the formatted price of the drink', () => {
+            expect(drink.formattedPrice).to.equal('£2.95');
+        });
+    });
+
     describe('when parsing a page with a drink that has no pricing information', () => {
         let drinksBoardPage: IDrinksBoardPage;
         let drink: Drink;


### PR DESCRIPTION
Closes #11, and also supports drinks sold in two-thirds (and so is virtually hipster proof).

@matt-rhys-jones knock yourself out.